### PR TITLE
着せ替え、模様替えのUI修正とローカルストレージへの保存

### DIFF
--- a/mobile/lib/constants/dress_up_options.dart
+++ b/mobile/lib/constants/dress_up_options.dart
@@ -2,11 +2,11 @@ import 'package:mobile/constants/display_option.dart';
 import 'package:mobile/constants/image_paths.dart';
 
 enum DressUpOptions implements DisplayOption {
-  normal,
   spring,
   summer,
   autumn,
-  winter;
+  winter,
+  normal;
 
   @override
   String get imagePath {

--- a/mobile/lib/constants/prefs_keys.dart
+++ b/mobile/lib/constants/prefs_keys.dart
@@ -5,4 +5,6 @@ class PrefsKeys {
   static const enableBGM = 'enableBGM';
   static const enableSE = 'enableSE';
   static const enableVoice = 'enableVoice';
+  static const dressUp = 'dressUp';
+  static const makeover = 'makeover';
 }

--- a/mobile/lib/pages/dress_up_page.dart
+++ b/mobile/lib/pages/dress_up_page.dart
@@ -33,7 +33,7 @@ class DressUpPage extends ConsumerWidget {
             Center(
               child: PanelGridView(
                 title: 'きせかえ',
-                subtitle: 'コーディネート一覧',
+                subtitle: 'きせかえ一覧',
                 onSelected: (DisplayOption value) {
                   notifier.setDressUp(value);
                 },

--- a/mobile/lib/pages/dress_up_page.dart
+++ b/mobile/lib/pages/dress_up_page.dart
@@ -37,6 +37,12 @@ class DressUpPage extends ConsumerWidget {
                 onSelected: (DisplayOption value) {
                   notifier.setDressUp(value);
                 },
+                onConfirm: () async {
+                  await notifier.storeDressUp();
+                  if (context.mounted) {
+                    context.go(RouterPaths.home);
+                  }
+                },
                 values: notifier.values,
                 selectedValue: state,
               ),

--- a/mobile/lib/pages/makeover_page.dart
+++ b/mobile/lib/pages/makeover_page.dart
@@ -34,7 +34,13 @@ class MakeoverPage extends ConsumerWidget {
                 title: '模様替え',
                 subtitle: '背景一覧',
                 onSelected: (DisplayOption value) {
-                  notifier.setDressUp(value);
+                  notifier.setMakeover(value);
+                },
+                onConfirm: () {
+                  notifier.storeMakeover();
+                  if (context.mounted) {
+                    context.go(RouterPaths.home);
+                  }
                 },
                 values: notifier.values,
                 selectedValue: state,

--- a/mobile/lib/providers/dress_up_notifier.dart
+++ b/mobile/lib/providers/dress_up_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:mobile/constants/display_option.dart';
 import 'package:mobile/constants/dress_up_options.dart';
+import 'package:mobile/repositories/shared_preferences_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dress_up_notifier.g.dart';
@@ -8,11 +9,19 @@ part 'dress_up_notifier.g.dart';
 class DressUpNotifier extends _$DressUpNotifier {
   @override
   DressUpOptions build() {
-    return DressUpOptions.normal;
+    return _loadInitialDressUpFromLocalStorage();
+  }
+
+  DressUpOptions _loadInitialDressUpFromLocalStorage() {
+    return SharedPreferencesRepository.instance.getDressUp();
   }
 
   void setDressUp(DisplayOption dressUp) {
     state = dressUp as DressUpOptions;
+  }
+
+  Future<void> storeDressUp() async {
+    await SharedPreferencesRepository.instance.setDressUp(state);
   }
 
   get values => DressUpOptions.values;

--- a/mobile/lib/providers/makeover_notifier.dart
+++ b/mobile/lib/providers/makeover_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:mobile/constants/display_option.dart';
 import 'package:mobile/constants/makeover_options.dart';
+import 'package:mobile/repositories/shared_preferences_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'makeover_notifier.g.dart';
@@ -8,11 +9,19 @@ part 'makeover_notifier.g.dart';
 class MakeoverNotifier extends _$MakeoverNotifier {
   @override
   MakeoverOptions build() {
-    return MakeoverOptions.spring;
+    return _loadInitialMakeoverFromLocalStorage();
   }
 
-  void setDressUp(DisplayOption dressUp) {
-    state = dressUp as MakeoverOptions;
+  MakeoverOptions _loadInitialMakeoverFromLocalStorage() {
+    return SharedPreferencesRepository.instance.getMakeover();
+  }
+
+  void setMakeover(DisplayOption makeover) {
+    state = makeover as MakeoverOptions;
+  }
+
+  Future<void> storeMakeover() async {
+    await SharedPreferencesRepository.instance.setMakeover(state);
   }
 
   get values => MakeoverOptions.values;

--- a/mobile/lib/repositories/shared_preferences_repository.dart
+++ b/mobile/lib/repositories/shared_preferences_repository.dart
@@ -1,4 +1,6 @@
 import 'package:mobile/constants/default_settings.dart';
+import 'package:mobile/constants/dress_up_options.dart';
+import 'package:mobile/constants/makeover_options.dart';
 import 'package:mobile/constants/prefs_keys.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -29,6 +31,14 @@ class SharedPreferencesRepository {
     await _prefs.setBool(PrefsKeys.enableVoice, enable);
   }
 
+  Future<void> setDressUp(DressUpOptions dressUp) async {
+    await _prefs.setInt(PrefsKeys.dressUp, dressUp.index);
+  }
+
+  Future<void> setMakeover(MakeoverOptions makeover) async {
+    await _prefs.setInt(PrefsKeys.makeover, makeover.index);
+  }
+
   bool getEnablePushNotification() {
     return _prefs.getBool(PrefsKeys.enablePushNotification) ??
         DefaultSettings.enablePushNotification;
@@ -44,5 +54,15 @@ class SharedPreferencesRepository {
 
   bool getEnableVoice() {
     return _prefs.getBool(PrefsKeys.enableVoice) ?? DefaultSettings.enableVoice;
+  }
+
+  DressUpOptions getDressUp() {
+    final index = _prefs.getInt(PrefsKeys.dressUp);
+    return DressUpOptions.values[index ?? 4];
+  }
+
+  MakeoverOptions getMakeover() {
+    final index = _prefs.getInt(PrefsKeys.makeover);
+    return MakeoverOptions.values[index ?? 0];
   }
 }

--- a/mobile/lib/widgets/panel_grid_view.dart
+++ b/mobile/lib/widgets/panel_grid_view.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile/constants/app_colors.dart';
@@ -17,6 +15,7 @@ class PanelGridView<T> extends StatelessWidget {
     required this.onSelected,
     required this.values,
     required this.selectedValue,
+    required this.onConfirm,
   });
 
   final String title;
@@ -24,6 +23,7 @@ class PanelGridView<T> extends StatelessWidget {
   final void Function(DisplayOption) onSelected;
   final List<DisplayOption> values;
   final DisplayOption selectedValue;
+  final Function onConfirm;
 
   @override
   Widget build(BuildContext context) {
@@ -83,7 +83,6 @@ class PanelGridView<T> extends StatelessWidget {
                   SizedBox(height: 8.h),
                 ],
               ),
-
             Row(
               children: [
                 SelectPanel(
@@ -129,11 +128,12 @@ class PanelGridView<T> extends StatelessWidget {
                   onPressed: () => context.go(RouterPaths.home),
                 ),
                 SizedBox(width: 10.w),
-                const CustomTextButton(
+                CustomTextButton(
                   text: '決定',
                   textColor: AppColors.white,
                   backgroundColor: AppColors.primaryGold,
-                ),
+                  onPressed: () => onConfirm(),
+                )
               ],
             )
           ],

--- a/mobile/lib/widgets/panel_grid_view.dart
+++ b/mobile/lib/widgets/panel_grid_view.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile/constants/app_colors.dart';
@@ -27,15 +29,15 @@ class PanelGridView<T> extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Container(
-      height: 661.h,
       width: 300.w,
       decoration: BoxDecoration(
-        color: AppColors.dialogBackground,
+        color: AppColors.menuBackground,
         borderRadius: BorderRadius.circular(4.r),
       ),
       child: Padding(
         padding: const EdgeInsets.all(20).w,
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             SizedBox(height: 12.h),
             Text(
@@ -48,31 +50,74 @@ class PanelGridView<T> extends StatelessWidget {
               style: theme.textTheme.titleSmall,
             ),
             SizedBox(height: 16.h),
-            Expanded(
-              child: Scrollbar(
-                thumbVisibility: true,
-                thickness: 6.h,
-                radius: Radius.circular(40.r),
-                child: GridView.builder(
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      crossAxisSpacing: 10,
-                      mainAxisSpacing: 10,
-                      childAspectRatio: 100 / 126,
-                    ),
-                    itemCount: values.length,
-                    itemBuilder: (context, index) {
-                      final value = values[index];
-                      return SelectPanel(
-                        title: value.name,
-                        imagePath: value.imagePath,
-                        onSelected: () => onSelected(value),
-                        isSelected: value == selectedValue,
-                        type: value.runtimeType,
-                      );
-                    }),
+            // SizedBox(height: 16.h),
+            // Expanded(
+            //   child: GridView.builder(
+            //       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            //         crossAxisCount: 2,
+            //         crossAxisSpacing: 10,
+            //         mainAxisSpacing: 10,
+            //         childAspectRatio: 100 / 126,
+            //       ),
+            //       itemCount: values.length,
+            //       itemBuilder: (context, index) {
+            //         final value = values[index];
+            //         return SelectPanel(
+            //           title: value.name,
+            //           imagePath: value.imagePath,
+            //           onSelected: () => onSelected(value),
+            //           isSelected: value == selectedValue,
+            //           type: value.runtimeType,
+            //         );
+            //       }),
+            // ),
+            if (values.length > 4)
+              Column(
+                children: [
+                  SelectPanel(
+                    values: values,
+                    selectedValue: selectedValue,
+                    onSelected: onSelected,
+                    index: 4,
+                  ),
+                  SizedBox(height: 8.h),
+                ],
               ),
+
+            Row(
+              children: [
+                SelectPanel(
+                  values: values,
+                  selectedValue: selectedValue,
+                  onSelected: onSelected,
+                  index: 0,
+                ),
+                const Spacer(),
+                SelectPanel(
+                  values: values,
+                  selectedValue: selectedValue,
+                  onSelected: onSelected,
+                  index: 1,
+                ),
+              ],
+            ),
+            SizedBox(height: 8.h),
+            Row(
+              children: [
+                SelectPanel(
+                  values: values,
+                  selectedValue: selectedValue,
+                  onSelected: onSelected,
+                  index: 2,
+                ),
+                const Spacer(),
+                SelectPanel(
+                  values: values,
+                  selectedValue: selectedValue,
+                  onSelected: onSelected,
+                  index: 3,
+                ),
+              ],
             ),
             SizedBox(height: 16.h),
             Row(

--- a/mobile/lib/widgets/select_panel.dart
+++ b/mobile/lib/widgets/select_panel.dart
@@ -1,25 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mobile/constants/app_colors.dart';
+import 'package:mobile/constants/display_option.dart';
 import 'package:mobile/constants/dress_up_options.dart';
 
-class SelectPanel<T> extends StatelessWidget {
+class SelectPanel extends StatelessWidget {
   const SelectPanel({
     super.key,
-    required this.title,
-    required this.imagePath,
     required this.onSelected,
-    required this.type,
     this.isSelected = false,
+    required this.values,
+    required this.index,
+    required this.selectedValue,
   });
-  final String title;
-  final String imagePath;
-  final VoidCallback onSelected;
+  final Function(DisplayOption) onSelected;
   final bool isSelected;
-  final T type;
+  final List<DisplayOption> values;
+  final int index;
+  final DisplayOption selectedValue;
 
   @override
   Widget build(BuildContext context) {
+    final title = values[index].name;
+    final imagePath = values[index].imagePath;
+    final isSelected = selectedValue == values[index];
+    final type = selectedValue.runtimeType;
     final theme = Theme.of(context);
     return Column(
       children: [
@@ -28,15 +33,19 @@ class SelectPanel<T> extends StatelessWidget {
           style: theme.textTheme.titleSmall,
         ),
         SizedBox(height: 8.h),
-        Expanded(
+        Container(
+          constraints: BoxConstraints(
+            maxWidth: 120.w,
+            maxHeight: 120.h,
+          ),
           child: Stack(
             children: [
               GestureDetector(
-                onTap: onSelected,
+                onTap: () => onSelected(values[index]),
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(12.r),
-                    color: AppColors.dialogBackground,
+                    color: AppColors.menuItemBackground,
                   ),
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(12.r),


### PR DESCRIPTION
# 実装内容
- 着せ替え、模様替え画面のUIをGridView→figma通りに修正
- 決定ボタン押下時にシェアプリに保存
- providerのbuild時にシェアプリから読み込み
- シェアプリ周りはsetting_notifierをパクりました。
<img src='https://github.com/user-attachments/assets/b2a11f01-c6b6-4005-ac9c-cce72e415f86' width=320>
<img src='https://github.com/user-attachments/assets/40e76f5b-50c2-49d3-9c12-83dc2b95d09e' width=320>
